### PR TITLE
fix issue #1

### DIFF
--- a/PulseStats.py
+++ b/PulseStats.py
@@ -74,14 +74,13 @@ class PulseStatsMeasurer(DigitalMeasurer):
             if self.lastState is None:
                 self.lastState = bitstate
 
+            if self.lastTime is None:
+                self.lastTime = t                
+
             if bitstate == self.lastState:
                 continue
 
-            self.lastState = bitstate
-
-            if self.lastTime is None:
-                self.lastTime = t
-                continue
+            self.lastState = bitstate            
 
             timeDelta = float(t - self.lastTime)
             self.lastTime = t


### PR DESCRIPTION
moved code to avoid twice continue and lost of first sample, now follow high signal widths 17.375, 17.813, 18.875 µs
produces

Hmin	17.375 µs
Hmean	18.021 µs

instead of

Hmin	17.812 µs
Hmean	18.344 µs

## full dump comparision

- PR version

```
ΔT	1.201377 ms
Nfalling	3 
Nrising	3 
fmin	2.184 kHz
fmax	2.22 kHz
fmean	2.202 kHz
Tstd	5.259 µs
Tavg	454.219 µs
Hmin	17.375 µs
Hmean	18.021 µs
HSDev	771.396 ns
Hmax	18.875 µs
Lmin	433.125 µs
Lmean	436.625 µs
LSDev	4.95 µs
Lmax	440.125 µs
```

- master version

```
ΔT	1.201377 ms
Nfalling	3 
Nrising	3 
fmin	2.184 kHz
fmax	2.22 kHz
fmean	2.202 kHz
Tstd	5.259 µs
Tavg	454.219 µs
Hmin	17.812 µs
Hmean	18.344 µs
HSDev	751.301 ns
Hmax	18.875 µs
Lmin	433.125 µs
Lmean	436.625 µs
LSDev	4.95 µs
Lmax	440.125 µs
```